### PR TITLE
Fixed extensions page not working

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,12 @@
+turnkey-dokuwiki-14.1 (1) turnkey; urgency=low
+
+  * Latest Debian Jessie package version of DokuWiki.
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Stefan Davis <nafets.sivad@gmail.com>  Tue, 26 Jan 2016 23:51:22 +1100
+
 turnkey-dokuwiki-14.0 (1) turnkey; urgency=low
 
   * Latest Debian Jessie package version of DokuWiki.

--- a/conf.d/main
+++ b/conf.d/main
@@ -2,6 +2,8 @@
 
 ADMIN_PASS=turnkey
 
+# remove xcache to fix turnkeylinux/tracker#495
+apt-get purge -y php5-xcache
 
 # convenience symlinks
 ln -s /usr/share/dokuwiki /var/www/webroot

--- a/plan/main
+++ b/plan/main
@@ -11,4 +11,3 @@ webmin-phpini
 
 php5-gd
 php5-cli
-php5-xcache


### PR DESCRIPTION
removed xcache as per https://github.com/turnkeylinux/tracker/issues/495