### PR TITLE
minor tweaks fro v14.1 release

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,8 +1,6 @@
 turnkey-dokuwiki-14.1 (1) turnkey; urgency=low
 
-  * Latest Debian Jessie package version of DokuWiki.
-  
-  * Removed php5-xcache package (resolves #495).
+  * Removed php5-xcache package (resolves #495].
 
   * Note: Please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.

--- a/conf.d/main
+++ b/conf.d/main
@@ -4,6 +4,7 @@ ADMIN_PASS=turnkey
 
 # remove xcache to fix turnkeylinux/tracker#495
 apt-get purge -y php5-xcache
+rm -f /etc/php5/cli/conf.d/20-xcache.ini
 
 # convenience symlinks
 ln -s /usr/share/dokuwiki /var/www/webroot


### PR DESCRIPTION
Tweaked changelog (patching now rather than rebuilding).

Also not sure if `/etc/php5/cli/conf.d/20-xcache.ini` needs removal in this appliance, but I did notice in some others that I worked on that if php5-xcache is pruged this file still remains and php complains about it. Even if it's not required for some strange reason, this won't break anything...